### PR TITLE
added makefile and using go modules instead of govendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+SHELL := /bin/bash
+DIR := $(shell pwd)
+BINARY_NAME := botb
+OUTPUTDIR := ${DIR}/bin
+
+.PHONY: all build-linux clean
+
+GOV111PREFIX := 
+GOV111 := $(shell expr `go version | cut -f2 -d.` \>= 11)
+ifeq "$(GOV111)" ""
+    GOV111PREFIX := env GO111MODULE=on 
+else
+	GOVERSION := $(shell expr `go version | cut -f2 -d.` \>= 11)
+	ifeq "$(GOVERSION)" ""
+		$(error must be running Go version 1.11 or newer, due to use of modules)
+	endif
+endif
+
+all: clean build-linux
+
+clean:
+	@echo ">> removing previous builds"
+	@rm -rf $(OUTPUTDIR)
+
+$(GOPATH):
+	GOPATH := $(HOME)/go
+
+build-linux:
+	@echo ">> running check for unused/missing packages in go.mod"
+	@go mod tidy
+	@echo ">> building binary"
+	$(GOV111PREFIX) GOOS=linux GOARCH=amd64 go build -o $(OUTPUTDIR)/$(BINARY_NAME)-linux-amd64 ./

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/micksmix/botb
+module github.com/brompwnie/botb
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/micksmix/botb
+
+go 1.12
+
+require (
+	github.com/kr/pty v1.1.5
+	github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926
+	golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/kr/pty v1.1.5 h1:hyz3dwM5QLc1Rfoz4FuWJQG5BN7tc6K1MndAUnGpQr4=
+github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
+github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926 h1:G3dpKMzFDjgEh2q1Z7zUUtKa8ViPtH+ocF0bE0g00O8=
+github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8 h1:1wopBVtVdWnn03fZelqdXTqk7U7zPQCb+T4rbU9ZEoU=
+golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Added a makefile that drops `govendor` and opts for Go v1.11+ use of modules. Makefile requires Go v1.11 and newer, so if desired to compile with Go <= v1.10, existing manual build instructions could be used.

I have tested this on Go v1.11.1 on Linux x64 and Go v1.12 on macOS. 