### PR TITLE
Added a Dockerfile to static compile a binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:latest as builder
+RUN mkdir /app 
+ADD . /app/ 
+WORKDIR /app 
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o "botb_$(uname -m)" . \
+  && ln -s "botb_$(uname -m)" botb
+
+FROM scratch
+COPY --from=builder /app/botb* /
+CMD ["/botb"]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ govendor add github.com/kr/pty
 go build -o botbsBinary
 ```
 
+Building a static binary in Docker:
+```
+docker build -t botb .
+docker run -it --name botb botb
+docker cp botb:/botb .
+docker rm botb
+```
+
 # Usage
 BOtB can be compiled into a binary for the targeted platform and supports the following usage
 ```


### PR DESCRIPTION
Compiling an arch specific version (especially when you're on a different arch like MacOS) for your target Docker is useful.

Added a Dockerfile for doing so, and updated the readme to cover it.