### PR TITLE
Added reverse DNS lookup feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ BOtB is a CLI tool which allows you to:
 - Break out of Privileged Containers
 - Force BOtB to always return a Exit Code of 0 (useful for non-blocking CI/CD)
 - Perform the above from the CLI arguments or from a YAML config file
+- Perform reverse DNS lookup
 
 # Installation
 
@@ -53,7 +54,7 @@ make
 BOtB can be compiled into a binary for the targeted platform and supports the following usage
 ```
 Usage of ./botb:
--aggr string
+  -aggr string
         Attempt to exploit RuncPWN (default "nil")
   -always-succeed
         Always set BOtB's Exit code to Zero
@@ -83,6 +84,8 @@ Usage of ./botb:
         Perform Recon of the Container ENV
   -region string
         Provide a AWS Region e.g eu-west-2 (default "nil")
+  -rev-dns string
+        Perform reverse DNS lookup on subnet. Parameter must be in CIDR notation, e.g., -rev-dns 192.168.0.0/24 (default "nil")
   -s3bucket string
         Provide a bucket name for S3 Push (default "nil")
   -s3push string

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ BOtB is a CLI tool which allows you to:
 - Identify UNIX domain sockets which support HTTP
 - Find and identify the Docker Daemon on UNIX domain sockets or on an interface
 - Analyze and identify sensitive strings in ENV and process in the ProcFS i.e /Proc/{pid}/Environ
-- Identify metadata services endpoints i.e http://169.254.169.254
+- Identify metadata services endpoints i.e http://169.254.169.254, http://metadata.google.internal/ and http://100.100.100.200/ 
 - Perform a container breakout via exposed Docker daemons
 - Perform a container breakout via CVE-2019-5736
 - Hijack host binaries with a custom payload

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ var verbosePtr, huntSockPtr, huntHttpPtr, huntDockerPtr, toJsonPtr, autopwnPtr, 
 var validSocks []string
 
 var exitCode int
-var pathPtr, aggressivePtr, hijackPtr, wordlistPtr, endpointList, pushToS3ptr, s3BucketPtr, awsRegionPtr, cgroupPtr, configPtr *string
+var pathPtr, aggressivePtr, hijackPtr, wordlistPtr, endpointList, pushToS3ptr, s3BucketPtr, awsRegionPtr, cgroupPtr, configPtr, revDNSPtr *string
 
 type IpAddress struct {
 	Address string
@@ -63,6 +63,7 @@ func main() {
 	cgroupPtr = flag.String("pwn-privileged", "nil", "Provide a command payload to try exploit --privilege CGROUP release_agent's")
 	alwaysSucceedPtr = flag.Bool("always-succeed", false, "Always set BOtB's Exit code to Zero")
 	configPtr = flag.String("config", "nil", "Load config from provided yaml file")
+   revDNSPtr = flag.String("rev-dns", "nil", "Perform reverse DNS lookup on subnet. Parameter must be in CIDR notation, e.g., -rev-dns 192.168.0.0/24")
 
 	flag.Parse()
 
@@ -179,6 +180,10 @@ func runCMDArgs() {
 	if *metaDataPtr {
 		checkMetadataServices(*endpointList)
 	}
+
+   if *revDNSPtr != "nil" {
+      reverseDNS(*revDNSPtr)
+   }
 
 	if *autopwnPtr {
 		autopwn(*pathPtr, *cicdPtr)

--- a/utils.go
+++ b/utils.go
@@ -521,13 +521,31 @@ func checkMetadataServices(endpointList string) {
 		}
 
 	} else {
-		if queryEndpoint("http://169.254.169.254:80/") {
-			exitCode = 1
-		}
 
 		if queryEndpoint("http://169.254.169.254:8080/") {
 			exitCode = 1
 		}
+
+		if *verbosePtr {
+			fmt.Println("[*] Attemp to query Azure, Amazon and Digital Ocean")
+		}
+		if queryEndpoint("http://169.254.169.254/") {
+			exitCode = 1
+		}
+		if *verbosePtr {
+			fmt.Println("[*] Attemp to query Google GCP")
+		}
+		if queryEndpoint("http://metadata.google.internal/") {
+			exitCode = 1
+		}
+		if *verbosePtr {
+			fmt.Println("[*] Attemp to query Alibaba Cloud")
+		}
+		if queryEndpoint("http://100.100.100.200/") {
+			exitCode = 1
+		}
+
+
 	}
 }
 

--- a/utils.go
+++ b/utils.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+   "math" 
 	"math/rand"
 	"net"
 	"net/http"
@@ -1040,3 +1041,30 @@ func debug(data []byte, err error) {
 		log.Fatalf("%s\n\n", err)
 	}
 }
+
+func reverseDNS(cidr string) {
+        fmt.Println("[*] Attemp to reverse DNS lookup:", cidr)
+        ip, subnet, err := net.ParseCIDR(cidr)
+        if err != nil {
+                return
+        }
+        split := strings.Split(cidr, "/")
+        bits, err := strconv.Atoi(split[1])
+        if err != nil {
+                return
+        }
+        size := int(math.Exp2(float64(32-bits)))
+        if size > 2 {
+                for i := 0 ; i < size ; i++ {
+                        if i > 0 && i < size-1 {
+                                ip = net.IPv4(subnet.IP[0] | byte((i & 0xff000000) >> 24),
+                                              subnet.IP[1] | byte((i & 0x00ff0000) >> 16),
+                                              subnet.IP[2] | byte((i & 0x0000ff00) >>  8),
+                                              subnet.IP[3] | byte((i & 0x000000ff) >>  0))
+                                reverse, _ := net.LookupAddr(ip.String())
+                                if reverse != nil {
+                                        fmt.Printf("[!] %s DNS entry: %s\n", ip.String(), strings.Join(reverse[:],", "))
+                                }
+                        }
+                }
+        }                                                                                                                                                                                                                                                                      }


### PR DESCRIPTION
it is possible to perform an ip reverse lookup (e.g. `nmap -sn -Pn -R 192.168.0.0/24`) on subnets during a botb run.